### PR TITLE
Add 6 missing items

### DIFF
--- a/index.html
+++ b/index.html
@@ -444,6 +444,7 @@
               <tr onclick="clickTable('tableMainHand',this); clickTable('tableStaff')"><td>Sageblade</td><td>Crafted</td><td>14</td><td>3</td><td>20</td><td></td><td></td><td></td><td></td><td>10</td><td></td><td></td><td></td></tr>
               <tr onclick="clickTable('tableMainHand',this); clickTable('tableStaff')"><td>Blade of the New Moon</td><td>Dire Maul</td><td>5</td><td></td><td></td><td>19</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
               <tr onclick="clickTable('tableMainHand',this); clickTable('tableStaff')"><td>Witchblade</td><td>Scholomance</td><td></td><td>8</td><td>14</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
+              <tr onclick="clickTable('tableMainHand',this); clickTable('tableStaff')"><td>Mind Carver</td><td>Dire Maul</td><td></td><td>8</td><td>12</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
               <tr onclick="clickTable('tableMainHand',this); clickTable('tableStaff')"><td>Inventor's Focal Sword</td><td>Maraudon</td><td></td><td></td><td></td><td></td><td></td><td></td><td>1%</td><td></td><td></td><td></td><td></td></tr>
               </tbody>
             </table>
@@ -465,6 +466,8 @@
               <tr onclick="clickTable('tableOffHand',this); clickTable('tableStaff')"><td>Tome of the Lost</td><td>UBRS</td><td>6</td><td>7</td><td>18</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
               <tr onclick="clickTable('tableOffHand',this); clickTable('tableStaff')"><td>Fire Runed Grimoire</td><td>MC</td><td>12</td><td>21</td><td>11</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
               <tr onclick="clickTable('tableOffHand',this); clickTable('tableStaff')"><td>Tome of Fiery Arcana</td><td>PvP</td><td></td><td></td><td></td><td></td><td>40</td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
+              <tr onclick="clickTable('tableOffHand',this); clickTable('tableStaff')"><td>Drakestone of Shadow Wrath</td><td>ST</td><td></td><td></td><td>7</td><td>21</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
+              <tr onclick="clickTable('tableOffHand',this); clickTable('tableStaff')"><td>Spirit of Aquementas</td><td>Quest</td><td></td><td></td><td>20</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
               </tbody>
             </table>
           </div>
@@ -575,6 +578,7 @@
               <tr onclick="clickTable('tableBack',this)" class="setAQ20"><td>Shroud of Unspoken Names</td><td>AQ20</td><td>16</td><td>9</td><td>18</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
               <tr onclick="clickTable('tableBack',this)"><td>Sapphiron Drape</td><td>Onyxia</td><td>10</td><td>17</td><td>14</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
               <tr onclick="clickTable('tableBack',this)"><td>Spritecaster Cape</td><td>BRD</td><td>4</td><td>4</td><td>14</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
+              <tr onclick="clickTable('tableBack',this)"><td>High Councillor’s Cloak of Shadow Wrath</td><td>BoE</td><td></td><td></td><td></td><td>21</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
               </tbody>
             </table>
           </div>
@@ -600,6 +604,7 @@
               <tr onclick="clickTable('tableChest',this)" class="setT1"><td>Felheart Robes</td><td>MC</td><td>31</td><td>20</td><td>13</td><td></td><td></td><td>1%</td><td></td><td></td><td></td><td></td><td></td></tr>
               <tr onclick="clickTable('tableChest',this)"><td>Flarecore Robe</td><td>Crafting</td><td>35</td><td></td><td>23</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
               <tr onclick="clickTable('tableChest',this)"><td>Dreamweave Vest</td><td>Crafting</td><td></td><td>9</td><td>18</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
+              <tr onclick="clickTable('tableChest',this)"><td>Robe of Winter Night</td><td>Crafting</td><td></td><td></td><td>40</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
               <tr onclick="clickTable('tableChest',this)" class="setUDC"><td>Robe of Undead Cleansing</td><td>Event</td><td>12</td><td>13</td><td>48</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
               </tbody>
             </table>
@@ -622,6 +627,7 @@
               <tr onclick="clickTable('tableWrists',this)" class="setT05"><td>Deathmist Bracers</td><td>Quest</td><td>12</td><td>12</td><td>8</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
               <tr onclick="clickTable('tableWrists',this)"><td>Sublime Wristguards</td><td>Dire Maul</td><td>6</td><td>10</td><td>12</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
               <tr onclick="clickTable('tableWrists',this)" class="setUDC"><td>Bracers of Undead Cleansing</td><td>Event</td><td>6</td><td>7</td><td>26</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
+              <tr onclick="clickTable('tableWrists',this)" class="setUDC"><td>Councillor’s Cuffs of Shadow Wrath</td><td>BoE</td><td></td><td></td><td>19</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
               </tbody>
             </table>
           </div>


### PR DESCRIPTION
Hi! I love your simulator, thanks for creating it!

While getting item upgrade recommendations, I was missing a few items. I'm playing era and fresh, and all of these items are in both.

- [Mind Carver](https://www.wowhead.com/classic/item=18396/mind-carver)
- [Drakestone of Shadow Wrath](https://www.wowhead.com/classic/item=10796/drakestone)
- [Spirit of Aquementas](https://www.wowhead.com/classic/item=11904/spirit-of-aquementas)
- [High Councillor’s Cloak of Shadow Wrath](https://www.wowhead.com/classic/item=10138/high-councillors-cloak)
- [Robe of Winter Night](https://www.wowhead.com/classic/item=14136/robe-of-winter-night)
- [Councillor’s Cuffs of Shadow Wrath](https://www.wowhead.com/classic/item=10096/councillors-cuffs)

Can you accept/merge this PR and release a new version to production? ( https://maarslet.github.io/WarlockSim/ )

Hope it helps! I might run into more improvements, if you're open to more PR's.

Thanks!