### PR TITLE
Added more missing items, changed BoE structure

### DIFF
--- a/index.html
+++ b/index.html
@@ -507,11 +507,12 @@
               <tr onclick="clickTable('tableHelmet',this)" class="setT3"><td>Plagueheart Circlet</td><td>Naxx</td><td>28</td><td>25</td><td>33</td><td></td><td></td><td>1%</td><td>2%</td><td></td><td></td><td></td><td></td></tr>
               <tr onclick="clickTable('tableHelmet',this)"><td>Mish'undare, Circlet of the Mind Flayer</td><td>BWL</td><td>15</td><td>24</td><td>35</td><td></td><td></td><td></td><td>2%</td><td></td><td></td><td></td><td></td></tr>
               <tr onclick="clickTable('tableHelmet',this)"><td>Spellweaver's Turban</td><td>UBRS</td><td></td><td>9</td><td>36</td><td></td><td></td><td>1%</td><td></td><td></td><td></td><td></td><td></td></tr>
+              <tr onclick="clickTable('tableHelmet',this)"><td>Green Lens of Shadow Wrath</td><td>Crafted</td><td>10</td><td></td><td></td><td>36</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
               <tr onclick="clickTable('tableHelmet',this)"><td>Preceptor's Hat</td><td>Naxx</td><td>18</td><td>24</td><td>51</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
               <tr onclick="clickTable('tableHelmet',this)"><td>Bloodvine Goggles</td><td>Crafted</td><td></td><td></td><td></td><td></td><td></td><td>2%</td><td>1%</td><td></td><td>9</td><td></td><td></td></tr>
               <tr onclick="clickTable('tableHelmet',this)"><td>The Hexxer's Cover</td><td>ZG</td><td>10</td><td>10</td><td>41</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
               <tr onclick="clickTable('tableHelmet',this)" class="setT05"><td>Deathmist Mask</td><td>Quest</td><td>24</td><td>24</td><td>16</td><td></td><td></td><td>1%</td><td></td><td></td><td></td><td></td><td></td></tr>
-              <tr onclick="clickTable('tableHelmet',this)"><td>Eye of Flame</td><td>BoE</td><td></td><td>10</td><td></td><td></td><td>43</td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
+              <tr onclick="clickTable('tableHelmet',this)"><td>Eye of Flame</td><td>World</td><td></td><td>10</td><td></td><td></td><td>43</td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
               <tr onclick="clickTable('tableHelmet',this)" class="setPvPRare"><td>Rank 10 Helmet</td><td>PvP</td><td>21</td><td>18</td><td>21</td><td></td><td></td><td></td><td>1%</td><td></td><td></td><td></td><td></td></tr>
               <tr onclick="clickTable('tableHelmet',this)" class="setPvPEpic"><td>Rank 13 Helmet</td><td>PvP</td><td>30</td><td>24</td><td>32</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
               <tr onclick="clickTable('tableHelmet',this)"><td>Crimson Felt Hat</td><td>Stratholme</td><td>8</td><td>8</td><td>30</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
@@ -528,7 +529,7 @@
               <tr onclick="clickTable('tableNeck',this)"><td>Amulet of Vek'nilash</td><td>AQ40</td><td>9</td><td>5</td><td>27</td><td></td><td></td><td></td><td>1%</td><td></td><td></td><td></td><td></td></tr>
               <tr onclick="clickTable('tableNeck',this)" style="background-color:#AAAAAA" name="activeItem"><td>Choker of the Fire Lord</td><td>MC</td><td>7</td><td>7</td><td>34</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
               <tr onclick="clickTable('tableNeck',this)"><td>Dark Advisor's Pendant</td><td>Scholomance</td><td>8</td><td>7</td><td></td><td>20</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
-              <tr onclick="clickTable('tableNeck',this)"><td>Diana's Pearl Necklace</td><td>Stratholme</td><td>8</td><td>8</td><td>9</td><td></td><td></td><td>1%</td><td></td><td></td><td></td><td></td><td></td></tr>
+              <tr onclick="clickTable('tableNeck',this)"><td>Nacreous Shell Necklace (Diana's Pearl Necklace)</td><td>Stratholme</td><td>8</td><td>8</td><td>9</td><td></td><td></td><td>1%</td><td></td><td></td><td></td><td></td><td></td></tr>
               <tr onclick="clickTable('tableNeck',this)"><td>Malice Stone Pendant</td><td>Naxx</td><td>9</td><td>8</td><td>28</td><td></td><td></td><td></td><td></td><td>13</td><td></td><td></td><td></td></tr>
               <tr onclick="clickTable('tableNeck',this)"><td>Charm of the Shifting Sands</td><td>AQ20</td><td>9</td><td>12</td><td>25</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
               <tr onclick="clickTable('tableNeck',this)"><td>Soul Corrupter's Necklace</td><td>ZG</td><td>10</td><td>16</td><td></td><td></td><td></td><td>1%</td><td></td><td></td><td></td><td></td><td></td></tr>
@@ -571,6 +572,7 @@
               <tr onclick="clickTable('tableBack',this)"><td>Cloak of the Necropolis</td><td>Naxx</td><td>12</td><td>11</td><td>26</td><td></td><td></td><td>1%</td><td>1%</td><td></td><td></td><td></td><td></td></tr>
               <tr onclick="clickTable('tableBack',this)"><td>Cloak of the Devoured</td><td>AQ40</td><td>11</td><td>10</td><td>30</td><td></td><td></td><td>1%</td><td></td><td></td><td></td><td></td><td></td></tr>
               <tr onclick="clickTable('tableBack',this)" style="background-color:#AAAAAA" name="activeItem"><td>Cloak of Consumption</td><td>ZG</td><td></td><td>10</td><td>23</td><td></td><td></td><td>1%</td><td></td><td></td><td></td><td></td><td></td></tr>
+              <tr onclick="clickTable('tableBack',this)"><td>Shroud of Arcane Mastery</td><td>BRD</td><td>10</td><td>11</td><td></td><td></td><td></td><td>1%</td><td></td><td></td><td></td><td></td><td></td></tr>
               <tr onclick="clickTable('tableBack',this)"><td>Cloak of the Brood Lord</td><td>BWL</td><td>10</td><td>14</td><td>28</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
               <tr onclick="clickTable('tableBack',this)"><td>Veil of Eclipse</td><td>Naxx</td><td>10</td><td>10</td><td>28</td><td></td><td></td><td></td><td></td><td>10</td><td></td><td></td><td></td></tr>
               <tr onclick="clickTable('tableBack',this)"><td>Cloak of the Hakkari Worshipers</td><td>ZG</td><td>6</td><td>6</td><td>23</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
@@ -578,7 +580,8 @@
               <tr onclick="clickTable('tableBack',this)" class="setAQ20"><td>Shroud of Unspoken Names</td><td>AQ20</td><td>16</td><td>9</td><td>18</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
               <tr onclick="clickTable('tableBack',this)"><td>Sapphiron Drape</td><td>Onyxia</td><td>10</td><td>17</td><td>14</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
               <tr onclick="clickTable('tableBack',this)"><td>Spritecaster Cape</td><td>BRD</td><td>4</td><td>4</td><td>14</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
-              <tr onclick="clickTable('tableBack',this)"><td>High Councillor’s Cloak of Shadow Wrath</td><td>BoE</td><td></td><td></td><td></td><td>21</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
+              <tr onclick="clickTable('tableBack',this)"><td>Stormpike Sage's Cloak</td><td>PvP</td><td>11</td><td></td><td>14</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
+              <tr onclick="clickTable('tableBack',this)"><td>BoE ... of Shadow Wrath</td><td>World</td><td></td><td></td><td></td><td>21</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
               </tbody>
             </table>
           </div>
@@ -591,6 +594,7 @@
               <tr onclick="clickTable('tableChest',this)"><td>Garb of Royal Ascension</td><td>AQ40</td><td>21</td><td></td><td>30</td><td></td><td></td><td>2%</td><td></td><td></td><td></td><td></td><td></td></tr>
               <tr onclick="clickTable('tableChest',this)" class="setT25"><td>Doomcaller's Robes</td><td>AQ40</td><td>23</td><td>17</td><td>41</td><td></td><td></td><td></td><td>1%</td><td>20</td><td></td><td></td><td></td></tr>
               <tr onclick="clickTable('tableChest',this)"><td>Crystal Webbed Robe</td><td>Naxx</td><td>25</td><td>19</td><td>53</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
+              <tr onclick="clickTable('tableChest',this)"><td>Necro-Knight's Garb</td><td>Naxx</td><td>32</td><td></td><td>37</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
               <tr onclick="clickTable('tableChest',this)"><td>Robe of Volatile Power</td><td>MC</td><td>10</td><td>15</td><td>23</td><td></td><td></td><td></td><td>2%</td><td></td><td></td><td></td><td></td></tr>
               <tr onclick="clickTable('tableChest',this)" style="background-color:#AAAAAA" name="activeItem" class="setT2"><td>Nemesis Robes</td><td>BWL</td><td>26</td><td>16</td><td>32</td><td></td><td></td><td></td><td>1%</td><td></td><td></td><td></td><td></td></tr>
               <tr onclick="clickTable('tableChest',this)"><td>Jade Inlaid Vestments</td><td>Ysondre</td><td>16</td><td>18</td><td>44</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
@@ -603,6 +607,7 @@
               <tr onclick="clickTable('tableChest',this)" class="setT05"><td>Deathmist Robe</td><td>Quest</td><td>27</td><td>22</td><td></td><td>12</td><td></td><td></td><td>1%</td><td></td><td></td><td></td><td></td></tr>
               <tr onclick="clickTable('tableChest',this)" class="setT1"><td>Felheart Robes</td><td>MC</td><td>31</td><td>20</td><td>13</td><td></td><td></td><td>1%</td><td></td><td></td><td></td><td></td><td></td></tr>
               <tr onclick="clickTable('tableChest',this)"><td>Flarecore Robe</td><td>Crafting</td><td>35</td><td></td><td>23</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
+              <tr onclick="clickTable('tableChest',this)"><td>Robes of the Royal Crown</td><td>BRD</td><td>19</td><td>12</td><td>18</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
               <tr onclick="clickTable('tableChest',this)"><td>Dreamweave Vest</td><td>Crafting</td><td></td><td>9</td><td>18</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
               <tr onclick="clickTable('tableChest',this)"><td>Robe of Winter Night</td><td>Crafting</td><td></td><td></td><td>40</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
               <tr onclick="clickTable('tableChest',this)" class="setUDC"><td>Robe of Undead Cleansing</td><td>Event</td><td>12</td><td>13</td><td>48</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
@@ -627,7 +632,7 @@
               <tr onclick="clickTable('tableWrists',this)" class="setT05"><td>Deathmist Bracers</td><td>Quest</td><td>12</td><td>12</td><td>8</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
               <tr onclick="clickTable('tableWrists',this)"><td>Sublime Wristguards</td><td>Dire Maul</td><td>6</td><td>10</td><td>12</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
               <tr onclick="clickTable('tableWrists',this)" class="setUDC"><td>Bracers of Undead Cleansing</td><td>Event</td><td>6</td><td>7</td><td>26</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
-              <tr onclick="clickTable('tableWrists',this)" class="setUDC"><td>Councillor’s Cuffs of Shadow Wrath</td><td>BoE</td><td></td><td></td><td>19</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
+              <tr onclick="clickTable('tableWrists',this)" class="setUDC"><td>BoE ... of Shadow Wrath</td><td>World</td><td></td><td></td><td></td><td>19</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
               </tbody>
             </table>
           </div>
@@ -749,6 +754,10 @@
               <tr onclick="clickTable('tableRing1',this)"><td>Ring of Eternal Flame</td><td>Naxx</td><td></td><td>10</td><td></td><td></td><td>34</td><td></td><td>1%</td><td></td><td></td><td></td><td></td></tr>
               <tr onclick="clickTable('tableRing1',this)"><td>Don Rodrigo's Band</td><td>PvP</td><td>7</td><td></td><td></td><td></td><td></td><td></td><td>1%</td><td>20</td><td></td><td></td><td></td></tr>
               <tr onclick="clickTable('tableRing1',this)"><td>Dragonslayer's Signet</td><td>Onyxia</td><td>12</td><td>12</td><td></td><td></td><td></td><td></td><td>1%</td><td></td><td></td><td></td><td></td></tr>
+              <tr onclick="clickTable('tableRing1',this)"><td>Cyclopean Band</td><td>BRD</td><td>8</td><td>7</td><td>9</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
+              <tr onclick="clickTable('tableRing1',this)"><td>Don Mauricio's Band of Domination</td><td>Scholo</td><td>5</td><td></td><td>11</td><td></td><td></td><td></td><td>1%</td><td></td><td></td><td></td><td></td></tr>
+              <tr onclick="clickTable('tableRing1',this)"><td>Underworld Band</td><td>World</td><td>10</td><td></td><td></td><td>14</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
+              <tr onclick="clickTable('tableRing1',this)"><td>Maiden’s Circle</td><td>World</td><td></td><td>7</td><td>18</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
               </tbody>
             </table>
           </div>
@@ -780,6 +789,10 @@
               <tr onclick="clickTable('tableRing2',this)"><td>Ring of Eternal Flame</td><td>Naxx</td><td></td><td>10</td><td></td><td></td><td>34</td><td></td><td>1%</td><td></td><td></td><td></td><td></td></tr>
               <tr onclick="clickTable('tableRing2',this)"><td>Don Rodrigo's Band</td><td>PvP</td><td>7</td><td></td><td></td><td></td><td></td><td></td><td>1%</td><td>20</td><td></td><td></td><td></td></tr>
               <tr onclick="clickTable('tableRing2',this)"><td>Dragonslayer's Signet</td><td>Onyxia</td><td>12</td><td>12</td><td></td><td></td><td></td><td></td><td>1%</td><td></td><td></td><td></td><td></td></tr>
+              <tr onclick="clickTable('tableRing2',this)"><td>Cyclopean Band</td><td>BRD</td><td>8</td><td>7</td><td>9</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
+              <tr onclick="clickTable('tableRing2',this)"><td>Don Mauricio's Band of Domination</td><td>Scholo</td><td>5</td><td></td><td>11</td><td></td><td></td><td></td><td>1%</td><td></td><td></td><td></td><td></td></tr>
+              <tr onclick="clickTable('tableRing2',this)"><td>Underworld Band</td><td>World</td><td>10</td><td></td><td></td><td>14</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
+              <tr onclick="clickTable('tableRing2',this)"><td>Maiden’s Circle</td><td>World</td><td></td><td>7</td><td>18</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
               </tbody>
             </table>
           </div>
@@ -803,6 +816,7 @@
               <tr onclick="clickTable('tableTrinket1',this)"><td>The Black Book (Not Added)</td><td>BWL</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
               <tr onclick="clickTable('tableTrinket1',this)"><td>Pimgib's Collar (Not Added)</td><td>Dire Maul</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
               <tr onclick="clickTable('tableTrinket1',this)"><td>Fetish of the Sand Reaver (Not Added)</td><td>AQ40</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
+              <tr onclick="clickTable('tableTrinket1',this)"><td>Burst of Knowledge</td><td>BRD</td><td></td><td></td><td>12</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
               </tbody>
             </table>
           </div>
@@ -826,6 +840,7 @@
               <tr onclick="clickTable('tableTrinket2',this)"><td>The Black Book (Not Added)</td><td>BWL</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
               <tr onclick="clickTable('tableTrinket2',this)"><td>Pimgib's Collar (Not Added)</td><td>Dire Maul</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
               <tr onclick="clickTable('tableTrinket2',this)"><td>Fetish of the Sand Reaver (Not Added)</td><td>AQ40</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
+              <tr onclick="clickTable('tableTrinket2',this)"><td>Burst of Knowledge</td><td>BRD</td><td></td><td></td><td>12</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
               </tbody>
             </table>
           </div>

--- a/index.html
+++ b/index.html
@@ -611,6 +611,7 @@
               <tr onclick="clickTable('tableChest',this)"><td>Dreamweave Vest</td><td>Crafting</td><td></td><td>9</td><td>18</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
               <tr onclick="clickTable('tableChest',this)"><td>Robe of Winter Night</td><td>Crafting</td><td></td><td></td><td>40</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
               <tr onclick="clickTable('tableChest',this)" class="setUDC"><td>Robe of Undead Cleansing</td><td>Event</td><td>12</td><td>13</td><td>48</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
+              <tr onclick="clickTable('tableChest',this)"><td>BoE ... of Shadow Wrath</td><td>World</td><td></td><td></td><td></td><td>21</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
               </tbody>
             </table>
           </div>
@@ -632,7 +633,7 @@
               <tr onclick="clickTable('tableWrists',this)" class="setT05"><td>Deathmist Bracers</td><td>Quest</td><td>12</td><td>12</td><td>8</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
               <tr onclick="clickTable('tableWrists',this)"><td>Sublime Wristguards</td><td>Dire Maul</td><td>6</td><td>10</td><td>12</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
               <tr onclick="clickTable('tableWrists',this)" class="setUDC"><td>Bracers of Undead Cleansing</td><td>Event</td><td>6</td><td>7</td><td>26</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
-              <tr onclick="clickTable('tableWrists',this)" class="setUDC"><td>BoE ... of Shadow Wrath</td><td>World</td><td></td><td></td><td></td><td>19</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
+              <tr onclick="clickTable('tableWrists',this)"><td>BoE ... of Shadow Wrath</td><td>World</td><td></td><td></td><td></td><td>21</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
               </tbody>
             </table>
           </div>
@@ -723,6 +724,7 @@
               <tr onclick="clickTable('tableFeet',this)" class="setT1"><td>Felheart Slippers</td><td>MC</td><td>23</td><td>11</td><td>18</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
               <tr onclick="clickTable('tableFeet',this)" class="setT05"><td>Deathmist Sandals</td><td>Quest</td><td>24</td><td>14</td><td>12</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
               <tr onclick="clickTable('tableFeet',this)"><td>Fire Striders</td><td>Stratholme</td><td></td><td></td><td></td><td></td><td>29</td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
+              <tr onclick="clickTable('tableFeet',this)"><td>BoE ... of Shadow Wrath</td><td>World</td><td></td><td></td><td></td><td>30</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
               </tbody>
             </table>
           </div>
@@ -859,6 +861,7 @@
               <tr onclick="clickTable('tableWand',this)"><td>Dragon's Touch</td><td>BWL</td><td>7</td><td>12</td><td>6</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
               <tr onclick="clickTable('tableWand',this)"><td>Stormrager</td><td>Quest</td><td>8</td><td>5</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
               <tr onclick="clickTable('tableWand',this)"><td>Pyric Caduceus</td><td>BRD</td><td></td><td></td><td></td><td></td><td>13</td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
+              <tr onclick="clickTable('tableWand',this)"><td>BoE ... of Shadow Wrath</td><td>World</td><td></td><td></td><td></td><td>13</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
               </tbody>
             </table>
           </div>


### PR DESCRIPTION
Hi! Some more changes :)

I added and changed the BoE/World drop items into a new generic name, because otherwise we have to list all different `of Shadow Wrath` items, which is **[a lot](https://www.wowhead.com/classic/items?filter=124;0;of+Shadow+Wrath)** (and they're not actually different). I chose this name:
```
BoE ... of Shadow Wrath
```

In addition, I added some more missing items:
- Maiden’s Circle
- Underworld Band
- Don Mauricio's Band of Domination
- Cyclopean Band
- Robes of the Royal Crown
- Necro-Knight's Garb
- Burst of Knowledge
- Stormpike Sage's Cloak
- Shroud of Arcane Mastery
- Green Lens of Shadow Wrath

And I changed some items:
- Nacreous Shell Necklace (item was renamed, previously known as Diana's Pearl Necklace)
- Eye of Flame (changed all sources of `BoE` to `World` for consistency)

Can you accept/merge this PR and release a new version to production? ( https://maarslet.github.io/WarlockSim/ )

Hope you like the changes!

Thanks!